### PR TITLE
fix(ci): e2e should not be called when the event dispatch is on produ…

### DIFF
--- a/.github/workflows/e2e-relay.yml
+++ b/.github/workflows/e2e-relay.yml
@@ -27,6 +27,7 @@ jobs:
           
       - name: Trigger workflow with SHA
         uses: actions/github-script@v7
+        if: ${{ github.event.client_payload.environment != 'production' }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
There was a bug in the `e2e-relay.yaml` which executed tests on production