### PR TITLE
fix: ci will upload codecov to main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,6 +96,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          override_branch: main
       
       - name: Set e2e check to success
         if: ${{ success() }}


### PR DESCRIPTION
this is because we are not running e2e on main
in addition there is no instrumentation in production